### PR TITLE
Fix PStore adapter

### DIFF
--- a/lib/moneta/adapters/pstore.rb
+++ b/lib/moneta/adapters/pstore.rb
@@ -1,4 +1,5 @@
 require 'pstore'
+require 'fileutils'
 
 module Moneta
   module Adapters


### PR DESCRIPTION
Adapter fails to create file store on Ruby 2.0. Specifically loading core file libs fixes the issue.
