### PR TITLE
Adds the quality spec I used to find malformed whitespace and tab characters

### DIFF
--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -3,18 +3,6 @@ if defined?(Encoding) && Encoding.default_external != "UTF-8"
 end
 
 describe "The library itself" do
-  def check_for_spec_defs_with_single_quotes(filename)
-    failing_lines = []
-
-    File.readlines(filename).each_with_index do |line,number|
-      failing_lines << number + 1 if line =~ /^(describe|it|context) {1}'{1}/
-    end
-
-    unless failing_lines.empty?
-      "#{filename} uses inconsistent single quotes on lines #{failing_lines.join(', ')}"
-    end
-  end
-
   def check_for_tab_characters(filename)
     failing_lines = []
     File.readlines(filename).each_with_index do |line,number|
@@ -56,18 +44,6 @@ describe "The library itself" do
         next if filename =~ exempt
         error_messages << check_for_tab_characters(filename)
         error_messages << check_for_extra_spaces(filename)
-      end
-    end
-    expect(error_messages.compact).to be_well_formed
-  end
-
-  it "uses double-quotes consistently in specs" do
-    included = /spec/
-    error_messages = []
-    Dir.chdir(File.expand_path("../", __FILE__)) do
-      `git ls-files`.split("\n").each do |filename|
-        next unless filename =~ included
-        error_messages << check_for_spec_defs_with_single_quotes(filename)
       end
     end
     expect(error_messages.compact).to be_well_formed


### PR DESCRIPTION
This spec was copied over from the bundler repository.  :sparkles:
