### PR TITLE
Fix formatting of backend matrix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ to upgrade to a real key/value store.
 
 ### Backend feature matrix
 
-__NOTE:__ <a name="backend-matrix">The backend matrix</a> is much more readable on rubydoc.info than on github. [Go there!](http://rubydoc.info/github/minad/moneta/master/file/README.md#backend-matrix)
+__NOTE:__ <a name="backend-matrix"></a> [The backend matrix]((http://rubydoc.info/github/minad/moneta/master/file/README.md#backend-matrix)) is much more readable on rubydoc.info than on github.
 
 <table>
 


### PR DESCRIPTION
GitHub displays all `a` elements as links, even if they are used as named anchors only.

This PR also shortens the paragraph by removing the superfluous “Go there!” link.
