### PR TITLE
FEATURE raise errors, because the client won't

### DIFF
--- a/lib/moneta/adapters/tokyotyrant.rb
+++ b/lib/moneta/adapters/tokyotyrant.rb
@@ -32,7 +32,7 @@ module Moneta
         elsif defined?(::TokyoTyrant::RDB)
           # Use ruby client
           @backend = ::TokyoTyrant::RDB.new
-          @backend.open(options[:host], options[:port]) or raise @backend.errmsg
+          @backend.open(options[:host], options[:port]) or error
         else
           # Use native client
           @backend = ::TokyoTyrant::DB.new(options[:host], options[:port])
@@ -48,13 +48,13 @@ module Moneta
       def load(key, options = {})
         value = @backend[key]
         # raise if there is an error and the error is not "no record"
-        raise error_message if value.nil? && @backend.ecode != ENOREC
+        error if value.nil? && @backend.ecode != ENOREC
         value && unpack(value)
       end
 
       # (see Proxy#store)
       def store(key, value, options = {})
-        @backend.put(key, pack(value)) or raise error_message
+        @backend.put(key, pack(value)) or error
         value
       end
 
@@ -62,14 +62,14 @@ module Moneta
       def delete(key, options = {})
         value = load(key, options)
         if value
-          @backend.delete(key) or raise error_message
+          @backend.delete(key) or error
           value
         end
       end
 
       # (see Proxy#increment)
       def increment(key, amount = 1, options = {})
-        @backend.addint(key, amount) || raise('Tried to increment non integer value')
+        @backend.addint(key, amount) or error
       end
 
       # (see Proxy#create)
@@ -119,8 +119,8 @@ module Moneta
         end
       end
 
-      def error_message
-        "#{@backend.class.name} error: #{@backend.errmsg}"
+      def error
+        raise "#{@backend.class.name} error: #{@backend.errmsg}"
       end
     end
   end


### PR DESCRIPTION
Most other client raise errors when error are encountered. For example, Memcache will do so when the value is too large.

Both tokyotyrant gems do not raise, so I've added code to check if an error has occurred.
# store and #delete will return false if the action failed.
# load will return nil if the record doesn't exist, or if an error occurred.
