### PR TITLE
Updated moped to 2.0, added compatibility for ruby_bson v1 and v2+

### DIFF
--- a/lib/moneta/adapters/mongo/base.rb
+++ b/lib/moneta/adapters/mongo/base.rb
@@ -30,7 +30,12 @@ module Moneta
         when 'Number'
           doc[@value_field]
         else
-          doc[@value_field].to_s
+          # In ruby_bson version 2 (and probably up), #to_s no longer returns the binary data
+          if doc[@value_field].is_a? ::BSON::Binary and defined? ::BSON::VERSION and ::BSON::VERSION[0].to_i >= 2
+            doc[@value_field].data
+          else
+            doc[@value_field].to_s
+          end
         end
       end
 

--- a/lib/moneta/adapters/mongo/moped.rb
+++ b/lib/moneta/adapters/mongo/moped.rb
@@ -106,7 +106,7 @@ module Moneta
       protected
 
       def to_binary(s)
-        ::Moped::BSON::Binary.new(:generic, s)
+        ::BSON::Binary.new(s)
       end
     end
   end


### PR DESCRIPTION
As discussed, updated moped to latest version.

Added compatibility for both `ruby_bson` v1 (currently used by `mongo`) and v2 (currently used by `moped`). Also made sure that if mongo updated to v2 in the future, things keep working like they should.

I've run the rspec tests for both official and moped. Moped succeeds with 0 failures. Official remains the same with 4 failures before and after my patch (mostly concurrency issues).
