### PR TITLE
Changes to Client/Server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 2.4
   - 2.3
   - 2.2
-  - jruby-9.2
+  - jruby-9.2.9.0
   - rbx-3
 services:
   - mysql
@@ -128,7 +128,7 @@ matrix:
       env: SCRIPT='rubocop lib'
     - rvm: 2.2
       env: SCRIPT='rubocop lib'
-    - rvm: jruby-9.2
+    - rvm: jruby-9.2.9.0
       env: SCRIPT='rubocop lib'
     - rvm: rbx-3
       env: SCRIPT='rubocop lib'

--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,9 @@ end
 
 # Rails integration testing
 group :rails do
-  gem 'actionpack', '~> 5.0'
+  git 'https://github.com/rails/rails.git', branch: '5-2-stable' do
+    gem 'actionpack'
+  end
   gem 'minitest', '~> 5.0'
 end
 

--- a/feature_matrix.yaml
+++ b/feature_matrix.yaml
@@ -220,13 +220,14 @@ backends:
   - adapter: Client
     platforms: [ MRI, JRuby ]
     features: [multiprocess]
-    unknown: [ increment, create, expires, persist ]
+    unknown: [ increment, create, expires, persist, each_key ]
     description: "Moneta client adapter"
     notes:
       increment: depends on server
       create: depends on server
       expires: depends on server
       persist: depends on server
+      each_key: depends on server
   - adapter: RestClient
     platforms: [ MRI, JRuby ]
     features: [ multiprocess ]

--- a/lib/moneta/lock.rb
+++ b/lib/moneta/lock.rb
@@ -15,6 +15,7 @@ module Moneta
     protected
 
     def wrap(name, *args, &block)
+      self.locks ||= Set.new
       if locked?
         yield
       else
@@ -22,8 +23,12 @@ module Moneta
       end
     end
 
+    def locks=(locks)
+      Thread.current.thread_variable_set('Moneta::Lock', locks)
+    end
+
     def locks
-      Thread.current['Moneta::Lock'] ||= Set.new
+      Thread.current.thread_variable_get('Moneta::Lock')
     end
 
     def lock!(&block)

--- a/lib/moneta/server.rb
+++ b/lib/moneta/server.rb
@@ -4,6 +4,128 @@ module Moneta
   # Moneta server to be used together with Moneta::Adapters::Client
   # @api public
   class Server
+    # @api private
+    class Connection
+      def initialize(io, store)
+        @io = io
+        @store = store
+        @fiber = Fiber.new { run }
+      end
+
+      def resume(result = nil)
+        @fiber.resume result
+      end
+
+      private
+
+      # The return value of this function will be sent to the reactor.
+      #
+      # @return [:closed,Exception]
+      def run
+        catch :closed do
+          loop { write_dispatch(read_msg) }
+        end
+        :closed
+      rescue => ex
+        ex
+      ensure
+        @io.close unless @io.closed?
+      end
+
+      def dispatch(method, args)
+        case method
+        when :key?, :load, :delete, :increment, :create
+          @store.send(method, *args)
+        when :features
+          # all features except each_key are supported
+          @store.features - [:each_key]
+        when :store, :clear
+          @store.send(method, *args)
+          nil
+        end
+      rescue => ex
+        ex
+      end
+
+      def write_dispatch(msg)
+        method, *args = msg
+        result = dispatch(method, args)
+        write(result)
+      end
+
+      def read_msg
+        size = read(4).unpack('N').first
+        throw :closed, 'Message too big' if size > MAXSIZE
+        Marshal.load(read(size))
+      end
+
+      def read(len)
+        buffer = ''
+        loop do
+          begin
+            case received = @io.recv_nonblock(len)
+            when '', nil
+              throw :closed, 'Closed during read'
+            else
+              buffer << received
+              len -= received.bytesize
+            end
+          rescue IO::WaitReadable, IO::WaitWritable
+            yield_to_reactor(:read)
+          rescue Errno::ECONNRESET
+            throw :closed, 'Closed during read'
+          rescue IOError => ex
+            if ex.message =~ /closed stream/
+              throw :closed, 'Closed during read'
+            else
+              raise
+            end
+          end
+          break if len == 0
+        end
+        buffer
+      end
+
+      def write(obj)
+        buffer = pack(obj)
+        until buffer.empty?
+          begin
+            len = sendmsg(buffer)
+            buffer = buffer.byteslice(len...buffer.length)
+          rescue IO::WaitWritable, Errno::EINTR
+            yield_to_reactor(:write)
+          end
+        end
+        nil
+      end
+
+      # Detect support for socket#sendmsg_nonblock
+      Socket.new(Socket::AF_INET, Socket::SOCK_STREAM).tap do |socket|
+        begin
+          socket.sendmsg_nonblock('probe')
+        rescue Errno::EPIPE
+          def sendmsg(msg)
+            @io.sendmsg_nonblock(msg)
+          end
+        rescue NotImplementedError
+          def sendmsg(msg)
+            @io.write_nonblock(msg)
+          end
+        end
+      end
+
+      def yield_to_reactor(mode = :read)
+        if Fiber.yield(mode) == :close
+          throw :closed, 'Closed by reactor'
+        end
+      end
+
+      def pack(obj)
+        s = Marshal.dump(obj)
+        [s.bytesize].pack('N') << s
+      end
+    end
+
     # @param [Hash] options
     # @option options [Integer] :port (9000) TCP port
     # @option options [String] :socket Alternative Unix socket file name
@@ -11,7 +133,9 @@ module Moneta
       @store = store
       @server = start(options)
       @ios = [@server]
-      @clients = {}
+      @reads = @ios.dup
+      @writes = []
+      @connections = {}
       @running = false
     end
 
@@ -26,23 +150,27 @@ module Moneta
     #
     # @note This method blocks!
     def run
-      raise 'Already running' if @running
+      raise 'Already running' if running?
       @stop = false
       @running = true
       begin
         mainloop until @stop
       ensure
-        File.unlink(@socket) if @socket
-        @ios.each { |io| io.close rescue nil }
+        @running = false
+        @server.close unless @server.closed?
+        @ios
+          .reject { |io| io == @server }
+          .each { |io| close_connection(io) }
+        File.unlink(@socket) if @socket rescue nil
       end
     end
 
     # Stop the server
     def stop
-      raise 'Not running' unless @running
+      raise 'Not running' unless running?
       @stop = true
       @server.close
-      @server = nil
+      nil
     end
 
     private
@@ -51,69 +179,63 @@ module Moneta
     MAXSIZE = 0x100000
 
     def mainloop
-      if ios = IO.select(@ios, nil, @ios, TIMEOUT)
-        ios[2].each do |io|
-          io.close
-          delete_client(io)
+      if ready = IO.select(@reads, @writes, @ios, TIMEOUT)
+        reads, writes, errors = ready
+        errors.each { |io| close_connection(io) }
+
+        @reads -= reads
+        reads.each do |io|
+          io == @server ? accept_connection : resume(io)
         end
-        ios[0].each do |io|
-          if io == @server
-            if client = @server.accept
-              @ios << client
-              @clients[client] = ''
-            end
-          elsif io.closed? || io.eof?
-            delete_client(io)
-          else
-            handle(io, @clients[io] << io.readpartial(0xFFFF))
-          end
-        end
+
+        @writes -= writes
+        writes.each { |io| resume(io) }
       end
-    rescue SignalException => ex
-      warn "Moneta::Server - #{ex.message}"
-      raise if ex.signo == 15 || ex.signo == 2 # SIGTERM or SIGINT
-    rescue => ex
-      warn "Moneta::Server - #{ex.message}"
-    end
-
-    def delete_client(io)
-      @ios.delete(io)
-      @clients.delete(io)
-    end
-
-    def pack(obj)
-      s = Marshal.dump(obj)
-      [s.bytesize].pack('N') << s
-    end
-
-    def handle(io, buffer)
-      return if buffer.bytesize < 8 # At least 4 bytes for the marshalled array
-      size = buffer[0, 4].unpack('N').first
-      if size > MAXSIZE
-        delete_client(io)
-        return
-      end
-      return if buffer.bytesize < 4 + size
-      buffer.slice!(0, 4)
-      method, *args = Marshal.load(buffer.slice!(0, size))
-      case method
-      when :key?, :load, :delete, :increment, :create
-        io.write(pack(@store.send(method, *args)))
-      when :features
-        # all features except each_key are supported
-        io.write(pack(@store.features - [:each_key]))
-      when :store, :clear
-        @store.send(method, *args)
-        io.write(@nil ||= pack(nil))
-      else
-        raise 'Invalid method call'
+    rescue SignalException => signal
+      warn "Moneta::Server - received #{signal}"
+      case signal.signo
+      when Signal.list['INT'], Signal.list['TERM']
+        @stop = true # graceful exit
       end
     rescue IOError => ex
-      warn "Moneta::Server - #{ex.message}" unless ex.message =~ /closed/
-      delete_client(io)
-    rescue => ex
+      # We get a lot of these "closed stream" errors, which we ignore
+      raise unless ex.message =~ /closed stream/
+    rescue Errno::EBADF => ex
       warn "Moneta::Server - #{ex.message}"
-      io.write(pack(Exception.new(ex.message)))
+    end
+
+    def accept_connection
+      io = @server.accept
+      @connections[io] = Connection.new(io, @store)
+      @ios << io
+      resume(io)
+    ensure
+      @reads << @server
+    end
+
+    def delete_connection(io)
+      @ios.delete(io)
+      @reads.delete(io)
+      @writes.delete(io)
+    end
+
+    def close_connection(io)
+      delete_connection(io)
+      @connections.delete(io).resume(:close)
+    end
+
+    def resume(io)
+      case result = @connections[io].resume
+      when :closed # graceful exit
+        delete_connection(io)
+      when Exception # messy exit
+        delete_connection(io)
+        raise result
+      when :read
+        @reads << io
+      when :write
+        @writes << io
+      end
     end
 
     def start(options)
@@ -132,6 +254,15 @@ module Moneta
       else
         TCPServer.open(options[:host] || '127.0.0.1', options[:port] || 9000)
       end
+    end
+
+    def stats
+      {
+        connections: @connections.length,
+        reading: @reads.length,
+        writing: @writes.length,
+        total: @ios.length
+      }
     end
   end
 end

--- a/lib/moneta/shared.rb
+++ b/lib/moneta/shared.rb
@@ -23,7 +23,7 @@ module Moneta
 
     # (see Proxy#close)
     def close
-      if @server
+      if server?
         @server.stop
         @thread.join
         @server = @thread = nil
@@ -34,13 +34,20 @@ module Moneta
       end
     end
 
+    # Returns true if this wrapper is running as the server
+    #
+    # @return [Boolean] wrapper is a server
+    def server?
+      @server != nil
+    end
+
     protected
 
     def wrap(*args)
       connect
       yield
     rescue Errno::ECONNRESET, Errno::EPIPE, IOError, SystemCallError
-      @connect_lock.synchronize { close unless @server }
+      @connect_lock.synchronize { close unless server? }
       tries ||= 0
       (tries += 1) < 3 ? retry : raise
     end
@@ -50,21 +57,22 @@ module Moneta
       @connect_lock.synchronize do
         @adapter ||= Adapters::Client.new(@options)
       end
-    rescue Errno::ECONNREFUSED, Errno::ENOENT => ex
+    rescue Errno::ECONNREFUSED, Errno::ENOENT, IOError => ex
       start_server
       tries ||= 0
       warn "Moneta::Shared - Failed to connect: #{ex.message}" if tries > 0
-      (tries += 1) < 3 ? retry : raise
+      (tries += 1) < 10 ? retry : raise
     end
 
     # TODO: Implement this using forking (MRI) and threading (JRuby)
     # to get maximal performance
     def start_server
       @connect_lock.synchronize do
+        return if server?
         begin
           raise "Adapter already set" if @adapter
           @adapter = Lock.new(@builder.build.last)
-          raise "Server already set" if @server
+          raise "Server already set" if server?
           @server = Server.new(@adapter, @options)
           @thread = Thread.new { @server.run }
           sleep 0.1 until @server.running?

--- a/lib/moneta/shared.rb
+++ b/lib/moneta/shared.rb
@@ -11,8 +11,6 @@ module Moneta
   #
   # @api public
   class Shared < Wrapper
-    not_supports :each_key
-
     # @param [Hash] options
     # @option options [Integer] :port (9000) TCP port
     # @option options [String] :host Server hostname

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -327,8 +327,13 @@ module MonetaHelpers
       server = Moneta::Server.new(*args)
       Thread.new { server.run }
       sleep 0.1 until server.running?
+      server
     rescue Exception => ex
       puts "Failed to start server - #{ex.message}"
+      tries ||= 0
+      tries += 1
+      sleep Moneta::Server::TIMEOUT
+      tries < 3 ? retry : raise
     end
 
     def moneta_property_of(keys: 0, values: 0)

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -323,19 +323,6 @@ module MonetaHelpers
       end
     end
 
-    def start_server(*args)
-      server = Moneta::Server.new(*args)
-      Thread.new { server.run }
-      sleep 0.1 until server.running?
-      server
-    rescue Exception => ex
-      puts "Failed to start server - #{ex.message}"
-      tries ||= 0
-      tries += 1
-      sleep Moneta::Server::TIMEOUT
-      tries < 3 ? retry : raise
-    end
-
     def moneta_property_of(keys: 0, values: 0)
       keys_meta = self.keys_meta
       values_meta = self.values_meta

--- a/spec/moneta/adapters/client/adapter_client_spec.rb
+++ b/spec/moneta/adapters/client/adapter_client_spec.rb
@@ -1,11 +1,15 @@
 describe 'adapter_client', isolate: true, adapter: :Client do
   before :all do
-    start_server(Moneta::Adapters::Memory.new)
+    @server = start_server(Moneta::Adapters::Memory.new)
+  end
+
+  after :all do
+    @server.stop
   end
 
   moneta_build do
     Moneta::Adapters::Client.new
   end
 
-  moneta_specs ADAPTER_SPECS
+  moneta_specs ADAPTER_SPECS.with_each_key
 end

--- a/spec/moneta/adapters/client/adapter_client_spec.rb
+++ b/spec/moneta/adapters/client/adapter_client_spec.rb
@@ -1,14 +1,10 @@
-describe 'adapter_client', isolate: true, adapter: :Client do
-  before :all do
-    @server = start_server(Moneta::Adapters::Memory.new)
-  end
+require_relative './client_helper.rb'
 
-  after :all do
-    @server.stop
-  end
+describe 'adapter_client', adapter: :Client do
+  include_context :start_server, port: 9002, backend: ->{ Moneta::Adapters::Memory.new }
 
   moneta_build do
-    Moneta::Adapters::Client.new
+    Moneta::Adapters::Client.new(port: 9002)
   end
 
   moneta_specs ADAPTER_SPECS.with_each_key

--- a/spec/moneta/adapters/client/client_helper.rb
+++ b/spec/moneta/adapters/client/client_helper.rb
@@ -1,0 +1,24 @@
+RSpec.shared_context :start_server do |**options|
+  before :context do
+    begin
+      options.each do |key, value|
+        options[key] = instance_exec(&value) if value.respond_to? :call
+      end
+      backend = options.delete(:backend)
+      @server = Moneta::Server.new(backend, options)
+      @thread = Thread.new { @server.run }
+      sleep 0.1 until @server.running?
+    rescue Exception => ex
+      puts "Failed to start server - #{ex.message}"
+      tries ||= 0
+      tries += 1
+      sleep Moneta::Server::TIMEOUT
+      tries < 3 ? retry : raise
+    end
+  end
+
+  after :context do
+    @server.stop
+    @thread.join
+  end
+end

--- a/spec/moneta/adapters/client/standard_client_tcp_spec.rb
+++ b/spec/moneta/adapters/client/standard_client_tcp_spec.rb
@@ -1,13 +1,9 @@
-describe "standard_client_tcp", isolate: true, adapter: :Client do
-  before :all do
-    @server = start_server(Moneta::Adapters::Memory.new)
-  end
+require_relative './client_helper.rb'
 
-  after :all do
-    @server.stop
-  end
+describe "standard_client_tcp", adapter: :Client do
+  include_context :start_server, port: 9003, backend: ->{ Moneta::Adapters::Memory.new }
 
-  moneta_store :Client
+  moneta_store :Client, port: 9003
   moneta_specs STANDARD_SPECS
 
   it 'supports multiple clients' do

--- a/spec/moneta/adapters/client/standard_client_tcp_spec.rb
+++ b/spec/moneta/adapters/client/standard_client_tcp_spec.rb
@@ -1,6 +1,10 @@
 describe "standard_client_tcp", isolate: true, adapter: :Client do
   before :all do
-    start_server(Moneta::Adapters::Memory.new)
+    @server = start_server(Moneta::Adapters::Memory.new)
+  end
+
+  after :all do
+    @server.stop
   end
 
   moneta_store :Client

--- a/spec/moneta/adapters/client/standard_client_unix_spec.rb
+++ b/spec/moneta/adapters/client/standard_client_unix_spec.rb
@@ -1,7 +1,11 @@
 describe "standard_client_unix", isolate: true, adapter: :Client do
   before :all do
-    start_server Moneta::Adapters::Memory.new,
-                 socket: File.join(tempdir, 'standard_client_unix')
+    @server = start_server Moneta::Adapters::Memory.new,
+                           socket: File.join(tempdir, 'standard_client_unix')
+  end
+
+  after :all do
+    @server.stop
   end
 
   moneta_store :Client do

--- a/spec/moneta/adapters/client/standard_client_unix_spec.rb
+++ b/spec/moneta/adapters/client/standard_client_unix_spec.rb
@@ -1,15 +1,12 @@
-describe "standard_client_unix", isolate: true, adapter: :Client do
-  before :all do
-    @server = start_server Moneta::Adapters::Memory.new,
-                           socket: File.join(tempdir, 'standard_client_unix')
-  end
+require_relative './client_helper.rb'
 
-  after :all do
-    @server.stop
-  end
+describe "standard_client_unix", adapter: :Client do
+  include_context :start_server,
+                  backend: ->{ Moneta::Adapters::Memory.new },
+                  socket: ->{ File.join(tempdir, 'standard_client_unix') }
 
   moneta_store :Client do
-    {socket: File.join(tempdir, 'standard_client_unix')}
+    { socket: File.join(tempdir, 'standard_client_unix') }
   end
 
   moneta_specs STANDARD_SPECS

--- a/spec/moneta/proxies/shared/shared_tcp_spec.rb
+++ b/spec/moneta/proxies/shared/shared_tcp_spec.rb
@@ -1,4 +1,4 @@
-describe "shared_tcp", isolate: true, proxy: :Shared do
+describe "shared_tcp", proxy: :Shared do
   moneta_build do
     tempdir = self.tempdir
     Moneta.build do
@@ -26,7 +26,7 @@ describe "shared_tcp", isolate: true, proxy: :Shared do
 
     it 'has the underlying adapter' do
       store.load('dummy')
-      expect(store.adapter.adapter).to be_a Moneta::Adapters::PStore
+      expect(store.adapter.adapter).to be_a Moneta::Adapters::GDBM
     end
   end
 

--- a/spec/moneta/proxies/shared/shared_tcp_spec.rb
+++ b/spec/moneta/proxies/shared/shared_tcp_spec.rb
@@ -22,6 +22,11 @@ describe "shared_tcp", proxy: :Shared do
 
   # The first store initialised will be running the server
   context "running as the server" do
+    before do
+      store.load('dummy')
+      expect(store.server?).to be true
+    end
+
     include_examples :shared_tcp
 
     it 'has the underlying adapter' do
@@ -33,6 +38,11 @@ describe "shared_tcp", proxy: :Shared do
   context "running as a client" do
     let!(:server_store) do
       new_store.tap { |store| store.load('dummy') } # Makes a connection
+    end
+
+    before do
+      store.load('dummy')
+      expect(store.server?).to be false
     end
 
     after do

--- a/spec/moneta/proxies/shared/shared_tcp_spec.rb
+++ b/spec/moneta/proxies/shared/shared_tcp_spec.rb
@@ -3,13 +3,13 @@ describe "shared_tcp", isolate: true, proxy: :Shared do
     tempdir = self.tempdir
     Moneta.build do
       use(:Shared, port: 9001) do
-        adapter :PStore, file: File.join(tempdir, 'shared_tcp')
+        adapter :GDBM, file: File.join(tempdir, 'shared_tcp')
       end
     end
   end
 
   shared_examples :shared_tcp do
-    moneta_specs ADAPTER_SPECS
+    moneta_specs ADAPTER_SPECS.with_each_key
 
     it 'shares values' do
       store['shared_key'] = 'shared_value'

--- a/spec/moneta/proxies/shared/shared_unix_spec.rb
+++ b/spec/moneta/proxies/shared/shared_unix_spec.rb
@@ -1,15 +1,15 @@
-describe "shared_unix", isolate: true, proxy: :Shared do
+describe "shared_unix", proxy: :Shared do
   moneta_build do
     tempdir = self.tempdir
     Moneta.build do
       use(:Shared, socket: File.join(tempdir, 'shared_unix.socket')) do
-        adapter :PStore, file: File.join(tempdir, 'shared_unix')
+        adapter :GDBM, file: File.join(tempdir, 'shared_unix')
       end
     end
   end
 
   shared_examples :shared_unix do
-    moneta_specs ADAPTER_SPECS
+    moneta_specs ADAPTER_SPECS.with_each_key
 
     it 'shares values' do
       store['shared_key'] = 'shared_value'
@@ -25,7 +25,7 @@ describe "shared_unix", isolate: true, proxy: :Shared do
 
     it "has the underlying adapter" do
       store.load('dummy')
-      expect(store.adapter.adapter).to be_a Moneta::Adapters::PStore
+      expect(store.adapter.adapter).to be_a Moneta::Adapters::GDBM
     end
   end
 


### PR DESCRIPTION
+ `Server` is rewritten to use a fiber per connection.  This makes handling stateful stuff like iterating over an enumerator easier.
+ `Server` also uses `_nonblock` methods to hopefully speed up IO
+ `each_key` is implemented on the Server/Client
+ `Client` now buffers reads if it doesn't manage to read the whole server response at once.