### PR TITLE
LRUHash: rewrite to take advantage of ordered hashes

### DIFF
--- a/spec/moneta/adapters/lruhash/adapter_lruhash_spec.rb
+++ b/spec/moneta/adapters/lruhash/adapter_lruhash_spec.rb
@@ -11,9 +11,9 @@ describe 'adapter_lruhash', adapter: :LRUHash do
     (1..1000).each do |i|
       store[i] = 'x'
       store[0].should == 'y'
-      store.instance_variable_get(:@entry).size.should == [10, i+1].min
+      store.instance_variable_get(:@backend).size.should == [10, i+1].min
       (0...[9, i-1].min).each do |j|
-        store.instance_variable_get(:@entry)[i-j].should_not be_nil
+        store.instance_variable_get(:@backend)[i-j].should_not be_nil
       end
       store.key?(i-9).should be false if i > 9
     end


### PR DESCRIPTION
Based on the `lru_redux` gem, in Ruby 1.9+ implementing an LRU hash is much simpler (and somewhat faster).