### PR TITLE
Builder: dup options before instantiating adapters/proxies

### DIFF
--- a/lib/moneta/builder.rb
+++ b/lib/moneta/builder.rb
@@ -17,12 +17,12 @@ module Moneta
       adapter = @proxies.first
       if Array === adapter
         klass, options, block = adapter
-        adapter = new_proxy(klass, options, &block)
+        adapter = new_proxy(klass, options.dup, &block)
         check_arity(klass, adapter, 1)
       end
       @proxies[1..-1].inject([adapter]) do |result, proxy|
         klass, options, block = proxy
-        proxy = new_proxy(klass, result.last, options, &block)
+        proxy = new_proxy(klass, result.last, options.dup, &block)
         check_arity(klass, proxy, 2)
         result << proxy
       end

--- a/spec/moneta/builder_spec.rb
+++ b/spec/moneta/builder_spec.rb
@@ -25,4 +25,26 @@ describe Moneta::Builder do
       end.build
     end.to raise_error /Please check/
   end
+
+  it 'dups options before passing them to each middleware' do
+    my_adapter = Class.new do
+      def initialize(options)
+        throw "a is missing" unless options.delete(:a)
+      end
+    end
+
+    my_middleware = Class.new do
+      def initialize(backend, options)
+        throw "a is missing" unless options.delete(:a)
+      end
+    end
+
+    options = { a: 1 }
+    Moneta::Builder.new do
+      use my_middleware, options
+      adapter my_adapter, options
+    end.build
+
+    expect(options).to include(a: 1)
+  end
 end


### PR DESCRIPTION
Fixes #173