### PR TITLE
Supporting exists? while retaining exists

### DIFF
--- a/lib/moneta/adapters/redis.rb
+++ b/lib/moneta/adapters/redis.rb
@@ -26,7 +26,11 @@ module Moneta
       # number as a time to live in seconds.
       def key?(key, options = {})
         with_expiry_update(key, default: nil, **options) do
-          @backend.exists(key)
+          if @backend.respond_to?(:exists?)
+            @backend.exists?(key)
+          else
+            @backend.exists(key)
+          end
         end
       end
 


### PR DESCRIPTION
This addresses #189 for users of the Redis gem >= 4.2 while retaining support for the 4.0 gem's lack of `#exists?`. Testing locally wasn't trivial but it is a pretty simple change and it looks like it works fine based on just using the gem as-is on my local.

Let me know what you think... hopefully this does away with all the spam in the log output.