### PR TITLE
Add github workflow to run RSpec

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,26 @@
+name: Ruby CI
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby-version: [3.0.x, 2.7.x, 2.6.x, 2.5.x, 2.4.x, 2.3.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler: latest
+        bundler-cache: true
+    - name: Run tests
+      run: bundle exec rspec


### PR DESCRIPTION
Travis CI is going away, so let's use GitHub actions instead.