### PR TITLE
transformer_marshal_escape_spec: add missing require

### DIFF
--- a/spec/moneta/proxies/transformer/transformer_marshal_escape_spec.rb
+++ b/spec/moneta/proxies/transformer/transformer_marshal_escape_spec.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 describe 'transformer_marshal_escape', proxy: :Transformer do
   moneta_build do
     Moneta.build do


### PR DESCRIPTION
This fixes an uninitialized constant error when specs without bundler.

## Before
```
$ rspec spec/moneta/proxies/transformer/transformer_marshal_escape_spec.rb
Run options: exclude {:unsupported=>true, :broken=>true}
...................................................................................................FF..

Failures:

  1) transformer_marshal_escape transform_value feature allows to bypass transformer with :raw
     Failure/Error: ::Marshal.load(::URI.decode_www_form_component(value))
     
     NameError:
       uninitialized constant URI
     Shared Example Group: :transform_value called from ./spec/helper.rb:296
     # ./spec/moneta/proxies/transformer/transformer_marshal_escape_spec.rb:10:in `block (2 levels) in <top (required)>'
     # ./spec/helper.rb:322:in `load_value'
     # ./spec/features/transform_value.rb:4:in `block (2 levels) in <top (required)>'

  2) transformer_marshal_escape transform_value feature allows to bypass transformer with raw syntactic sugar
     Failure/Error: ::Marshal.load(::URI.decode_www_form_component(value))
     
     NameError:
       uninitialized constant URI
     Shared Example Group: :transform_value called from ./spec/helper.rb:296
     # ./spec/moneta/proxies/transformer/transformer_marshal_escape_spec.rb:10:in `block (2 levels) in <top (required)>'
     # ./spec/helper.rb:322:in `load_value'
     # ./spec/features/transform_value.rb:13:in `block (2 levels) in <top (required)>'

Finished in 2.82 seconds (files took 0.10661 seconds to load)
103 examples, 2 failures

Failed examples:

rspec ./spec/moneta/proxies/transformer/transformer_marshal_escape_spec.rb[1:12:1] # transformer_marshal_escape transform_value feature allows to bypass transformer with :raw
rspec ./spec/moneta/proxies/transformer/transformer_marshal_escape_spec.rb[1:12:2] # transformer_marshal_escape transform_value feature allows to bypass transformer with raw syntactic sugar
```

## After
```
$ rspec spec/moneta/proxies/transformer/transformer_marshal_escape_spec.rb
Run options: exclude {:unsupported=>true, :broken=>true}
.......................................................................................................

Finished in 2.98 seconds (files took 0.1179 seconds to load)
103 examples, 0 failures
```