### PR TITLE
Fix deprecation warnings for redis 4.6+ multi/pipelined handling

### DIFF
--- a/lib/moneta/adapters/redis.rb
+++ b/lib/moneta/adapters/redis.rb
@@ -21,11 +21,11 @@ module Moneta
       # This method considers false and 0 as "no-expire" and every positive
       # number as a time to live in seconds.
       def key?(key, options = {})
-        with_expiry_update(key, default: nil, **options) do
-          if @backend.respond_to?(:exists?)
-            @backend.exists?(key)
+        with_expiry_update(key, default: nil, **options) do |pipeline_handle|
+          if pipeline_handle.respond_to?(:exists?)
+            pipeline_handle.exists?(key)
           else
-            @backend.exists(key)
+            pipeline_handle.exists(key)
           end
         end
       end
@@ -40,8 +40,8 @@ module Moneta
 
       # (see Proxy#load)
       def load(key, options = {})
-        with_expiry_update(key, default: nil, **options) do
-          @backend.get(key)
+        with_expiry_update(key, default: nil, **options) do |pipeline_handle|
+          pipeline_handle.get(key)
         end
       end
 
@@ -59,17 +59,17 @@ module Moneta
       # (see Proxy#delete)
       def delete(key, options = {})
         future = nil
-        @backend.pipelined do
-          future = @backend.get(key)
-          @backend.del(key)
+        @backend.pipelined do |pipeline|
+          future = pipeline.get(key)
+          pipeline.del(key)
         end
         future.value
       end
 
       # (see Proxy#increment)
       def increment(key, amount = 1, options = {})
-        with_expiry_update(key, **options) do
-          @backend.incrby(key, amount)
+        with_expiry_update(key, **options) do |pipeline_handle|
+          pipeline_handle.incrby(key, amount)
         end
       end
 
@@ -84,7 +84,7 @@ module Moneta
         expires = expires_value(options, config.expires)
 
         if @backend.setnx(key, value)
-          update_expires(key, expires)
+          update_expires(@backend, key, expires)
           true
         else
           false
@@ -99,8 +99,8 @@ module Moneta
 
       # (see Defaults#values_at)
       def values_at(*keys, **options)
-        with_expiry_update(*keys, default: nil, **options) do
-          @backend.mget(*keys)
+        with_expiry_update(*keys, default: nil, **options) do |pipeline_handle|
+          pipeline_handle.mget(*keys)
         end
       end
 
@@ -126,8 +126,8 @@ module Moneta
           end
         end
 
-        with_expiry_update(*keys, **options) do
-          @backend.mset(*pairs.to_a.flatten(1))
+        with_expiry_update(*keys, **options) do |pipeline_handle|
+          pipeline_handle.mset(*pairs.to_a.flatten(1))
         end
 
         self
@@ -135,24 +135,33 @@ module Moneta
 
       protected
 
-      def update_expires(key, expires)
+      def update_expires(pipeline_handle, key, expires)
         case expires
         when false
-          @backend.persist(key)
+          pipeline_handle.persist(key)
         when Numeric
-          @backend.pexpire(key, (expires * 1000).to_i)
+          pipeline_handle.pexpire(key, (expires * 1000).to_i)
         end
       end
 
       def with_expiry_update(*keys, default: config.expires, **options)
         expires = expires_value(options, default)
         if expires == nil
-          yield
+          yield(@backend)
         else
           future = nil
-          @backend.multi do
-            future = yield
-            keys.each { |key| update_expires(key, expires) }
+          @backend.multi do |pipeline|
+            # as of redis 4.6 calling redis methods on the redis client itself
+            # is deprecated in favor of a pipeline handle provided by the
+            # +multi+ call. This will cause in error in redis >= 5.0.
+            #
+            # In order to continue supporting redis versions < 4.6, the following
+            # fallback has been introduced and can be removed once moneta 
+            # no longer supports redis < 4.6.
+            
+            pipeline_handle = pipeline || @backend
+            future = yield(pipeline_handle)
+            keys.each { |key| update_expires(pipeline_handle, key, expires) }
           end
           future.value
         end


### PR DESCRIPTION
As of version 4.6 of the redis gem, the following deprecation warning is emitted:

    Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.
    
    redis.multi do
      redis.get("key")
    end
    
    should be replaced by
    
    redis.multi do |pipeline|
      pipeline.get("key")
    end
    
    (called from [...]/gems/moneta-1.4.2/lib/moneta/adapters/redis.rb:157:in `with_expiry_update'}

This PR silences those expirations by passing a "pipeline handle", which uses the new block parameter mentioned in the deprecation message and falling back to the regular `@backend` variable as used before, if no block parameter is present.

The specs for the redis handler are green for me with redis version 4.5.1 and 4.6.0; not sure how this should be handled in the unit tests (if at all).