### PR TITLE
allow overriding socket in test suite

### DIFF
--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -269,6 +269,7 @@ module MonetaHelpers
       # want to run the tests but don't want to grant root access to moneta
       let(:mysql_host) { ENV['MYSQL_HOST'] || 'localhost' }
       let(:mysql_port) { ENV['MYSQL_TCP_PORT'] || '3306' }
+      let(:mysql_socket) { ENV['MYSQL_SOCKET'] }
       let(:mysql_username) { ENV['MONETA_MYSQL_USERNAME'] || 'root' }
       let(:mysql_password) { ENV['MONETA_MYSQL_PASSWORD'] }
       let(:mysql_database1) { ENV['MONETA_MYSQL_DATABASE1'] || 'moneta' }

--- a/spec/moneta/adapters/activerecord/adapter_activerecord_existing_connection_spec.rb
+++ b/spec/moneta/adapters/activerecord/adapter_activerecord_existing_connection_spec.rb
@@ -8,6 +8,7 @@ describe 'adapter_activerecord_existing_connection', adapter: :ActiveRecord, mys
     ActiveRecord::Base.configurations = {
       default_env => {
         'adapter' => (defined?(JRUBY_VERSION) ? 'jdbcmysql' : 'mysql2'),
+        'socket' => mysql_socket,
         'host' => mysql_host,
         'port' => mysql_port,
         'database' => mysql_database1,

--- a/spec/moneta/adapters/activerecord/adapter_activerecord_spec.rb
+++ b/spec/moneta/adapters/activerecord/adapter_activerecord_spec.rb
@@ -64,6 +64,7 @@ describe 'adapter_activerecord', adapter: :ActiveRecord do
         adapter: (defined?(JRUBY_VERSION) ? 'jdbcmysql' : 'mysql2'),
         host: mysql_host,
         port: mysql_port,
+        socket: mysql_socket,
         database: mysql_database1,
         username: mysql_username,
         password: mysql_password
@@ -75,6 +76,7 @@ describe 'adapter_activerecord', adapter: :ActiveRecord do
         adapter: (defined?(JRUBY_VERSION) ? 'jdbcmysql' : 'mysql2'),
         host: mysql_host,
         port: mysql_port,
+        socket: mysql_socket,
         database: mysql_database2,
         username: mysql_username,
         password: mysql_password

--- a/spec/moneta/adapters/activerecord/standard_activerecord_spec.rb
+++ b/spec/moneta/adapters/activerecord/standard_activerecord_spec.rb
@@ -6,6 +6,7 @@ describe "standard_activerecord", adapter: :ActiveRecord, mysql: true do
         adapter: (defined?(JRUBY_VERSION) ? 'jdbcmysql' : 'mysql2'),
         host: mysql_host,
         port: mysql_port,
+        socket: mysql_socket,
         database: mysql_database1,
         username: mysql_username,
         password: mysql_password

--- a/spec/moneta/adapters/activerecord/standard_activerecord_with_expires_spec.rb
+++ b/spec/moneta/adapters/activerecord/standard_activerecord_with_expires_spec.rb
@@ -10,6 +10,7 @@ describe "standard_activerecord_with_expires", adapter: :ActiveRecord, mysql: tr
         adapter: (defined?(JRUBY_VERSION) ? 'jdbcmysql' : 'mysql2'),
         host: mysql_host,
         port: mysql_port,
+        socket: mysql_socket,
         database: mysql_database1,
         username: mysql_username,
         password: mysql_password

--- a/spec/moneta/adapters/datamapper/adapter_datamapper_spec.rb
+++ b/spec/moneta/adapters/datamapper/adapter_datamapper_spec.rb
@@ -8,7 +8,7 @@ describe 'adapter_datamapper', unsupported: defined?(JRUBY_VERSION) || RUBY_ENGI
 
   moneta_build do
     Moneta::Adapters::DataMapper.new(
-      setup: "mysql://#{mysql_username}:#{mysql_password}@#{mysql_host}:#{mysql_port}/#{mysql_database1}",
+      setup: "mysql://#{mysql_username}:#{mysql_password}@#{mysql_host}:#{mysql_port}/#{mysql_database1}" + mysql_socket ? "?socket=#{mysql_socket}" : "",
       table: "adapter_datamapper"
     )
   end
@@ -17,14 +17,14 @@ describe 'adapter_datamapper', unsupported: defined?(JRUBY_VERSION) || RUBY_ENGI
 
   it 'does not cross contaminate when storing' do
     first = Moneta::Adapters::DataMapper.new(
-      setup: "mysql://#{mysql_username}:#{mysql_password}@#{mysql_host}:#{mysql_port}/#{mysql_database1}",
+      setup: "mysql://#{mysql_username}:#{mysql_password}@#{mysql_host}:#{mysql_port}/#{mysql_database1}" + mysql_socket ? "?socket=#{mysql_socket}" : "",
       table: "datamapper_first"
     )
     first.clear
 
     second = Moneta::Adapters::DataMapper.new(
       repository: :sample,
-      setup: "mysql://#{mysql_username}:#{mysql_password}@#{mysql_host}:#{mysql_port}/#{mysql_database1}",
+      setup: "mysql://#{mysql_username}:#{mysql_password}@#{mysql_host}:#{mysql_port}/#{mysql_database1}" + mysql_socket ? "?socket=#{mysql_socket}" : "",
       table: "datamapper_second"
     )
     second.clear
@@ -38,14 +38,14 @@ describe 'adapter_datamapper', unsupported: defined?(JRUBY_VERSION) || RUBY_ENGI
 
   it 'does not cross contaminate when deleting' do
     first = Moneta::Adapters::DataMapper.new(
-      setup: "mysql://#{mysql_username}:#{mysql_password}@#{mysql_host}:#{mysql_port}/#{mysql_database1}",
+      setup: "mysql://#{mysql_username}:#{mysql_password}@#{mysql_host}:#{mysql_port}/#{mysql_database1}" + mysql_socket ? "?socket=#{mysql_socket}" : "",
       table: "datamapper_first"
     )
     first.clear
 
     second = Moneta::Adapters::DataMapper.new(
       repository: :sample,
-      setup: "mysql://#{mysql_username}:#{mysql_password}@#{mysql_host}:#{mysql_port}/#{mysql_database1}",
+      setup: "mysql://#{mysql_username}:#{mysql_password}@#{mysql_host}:#{mysql_port}/#{mysql_database1}" + mysql_socket ? "?socket=#{mysql_socket}" : "",
       table: "datamapper_second"
     )
     second.clear

--- a/spec/moneta/adapters/datamapper/standard_datamapper_spec.rb
+++ b/spec/moneta/adapters/datamapper/standard_datamapper_spec.rb
@@ -8,7 +8,7 @@ describe "standard_datamapper", unsupported: defined?(JRUBY_VERSION) || RUBY_ENG
 
   moneta_store :DataMapper do
     {
-      setup: "mysql://#{mysql_username}:#{mysql_password}@#{mysql_host}:#{mysql_port}/#{mysql_database1}",
+      setup: "mysql://#{mysql_username}:#{mysql_password}@#{mysql_host}:#{mysql_port}/#{mysql_database1}" + mysql_socket ? "?socket=#{mysql_socket}" : "",
       table: "simple_datamapper"
     }
   end

--- a/spec/moneta/adapters/datamapper/standard_datamapper_with_expires_spec.rb
+++ b/spec/moneta/adapters/datamapper/standard_datamapper_with_expires_spec.rb
@@ -12,7 +12,7 @@ describe "standard_datamapper_with_expires", unsupported: defined?(JRUBY_VERSION
 
   moneta_store :DataMapper do
     {
-      setup: "mysql://#{mysql_username}:#{mysql_password}@#{mysql_host}:#{mysql_port}/#{mysql_database1}",
+      setup: "mysql://#{mysql_username}:#{mysql_password}@#{mysql_host}:#{mysql_port}/#{mysql_database1}" + mysql_socket ? "?socket=#{mysql_socket}" : "",
       table: "simple_datamapper_with_expires",
       expires: true
     }

--- a/spec/moneta/adapters/datamapper/standard_datamapper_with_repository_spec.rb
+++ b/spec/moneta/adapters/datamapper/standard_datamapper_with_repository_spec.rb
@@ -9,7 +9,7 @@ describe 'standard_datamapper_with_repository', unsupported: defined?(JRUBY_VERS
   moneta_store :DataMapper do
     {
       repository: :repo,
-      setup: "mysql://#{mysql_username}:#{mysql_password}@#{mysql_host}:#{mysql_port}/#{mysql_database1}",
+      setup: "mysql://#{mysql_username}:#{mysql_password}@#{mysql_host}:#{mysql_port}/#{mysql_database1}" + mysql_socket ? "?socket=#{mysql_socket}" : "",
       table: "simple_datamapper_with_repository"
     }
   end

--- a/spec/moneta/adapters/sequel/helper.rb
+++ b/spec/moneta/adapters/sequel/helper.rb
@@ -4,9 +4,12 @@ RSpec.shared_context :sequel do
     if defined?(JRUBY_VERSION)
       uri = "jdbc:mysql://#{mysql_host}:#{mysql_port}/#{database}?user=#{mysql_username}&useSSL=false"
       uri += "&password=#{mysql_password}" if mysql_password
+      uri += "&socket=#{mysql_socket}" if mysql_socket
       uri
     else
-      "mysql2://#{mysql_username}:#{mysql_password}@#{mysql_host}:#{mysql_port}/#{database}"
+      uri = "mysql2://#{mysql_username}:#{mysql_password}@#{mysql_host}:#{mysql_port}/#{database}"
+      uri += "?socket=#{mysql_socket}" if mysql_socket
+      uri
     end
   end
 


### PR DESCRIPTION
Debian has been carrying a patch to allow for tests to run on the
MySQL socket instead of localhost for a while, but has never been
proposed upstream. This is an attempt at forward-porting this patch
from 1.0 to 1.5.

The reason we do this is (presumably!) that our test suites might run
without network and it seems more reliable to test on the socket.