### PR TITLE
use Dir.glob instead of git ls-files in gemspec

### DIFF
--- a/moneta.gemspec
+++ b/moneta.gemspec
@@ -9,9 +9,9 @@ Gem::Specification.new do |s|
   s.email            = %w{mail@daniel-mendler.de wycats@gmail.com hannes.georg@googlemail.com me@asph.dev}
   s.description      = 'A unified interface to key/value stores'
   s.extra_rdoc_files = %w{README.md SPEC.md LICENSE}
-  s.files            = `git ls-files`.split("\n")
-  s.test_files       = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables      = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files            = Dir.glob('**/*') # all files
+  s.test_files       = Dir.glob('{test,spec,features}/*')
+  s.executables      = Dir.glob('bin/*').map{ |f| File.basename(f) }
   s.homepage         = 'https://github.com/moneta-rb/moneta'
   s.licenses         = %w(MIT)
   s.require_paths    = %w(lib)


### PR DESCRIPTION
Moneta is packaged in Debian, but only at version 1.0. Updating to the
latest version leads to build failures because we do *not* have Git
installed in the build tree: we instead copy a git archive to the
build servers. Details of the build errors are here:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1010286#12

I'm not so familiar with the Ruby build process, but from what I
understand, it is actually discouraged to use git in the gemspec in
that way:

https://packaging.rubystyle.guide/#using-git-in-gemspec

I am therefore using the recommended `Dir.glob()` instead of
`git ls-files`.