### PR TITLE
CI: lock activerecord to 5.2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ group :Daybreak, optional: true do
 end
 
 group :ActiveRecord, optional: true do
-  gem 'activerecord', '~> 5.2'
+  gem 'activerecord', '5.2.7'
 end
 
 group :Redis, optional: true do


### PR DESCRIPTION
5.2.8 seems to fail on Ruby 3, and I've run into trouble upgrading Moneta to work with 6+, so for now let's try pinning 5.2.7.