### PR TITLE
Tests: make the default_expires tests more basic and focused on expiry

### DIFF
--- a/spec/features/default_expires.rb
+++ b/spec/features/default_expires.rb
@@ -41,7 +41,8 @@ shared_examples :default_expires do
     include_examples :load, :fetch
   end
 
-  describe '#create' do
+  # Disabled for now, as not all adapters support #create
+  skip '#create' do
     it 'sets the default expiration time' do
       store.create('key1', 'val1')
       expect(store['key1']).to eq 'val1'

--- a/spec/features/default_expires.rb
+++ b/spec/features/default_expires.rb
@@ -1,14 +1,175 @@
 shared_examples :default_expires do
-  it 'sets the default expiration time', default_expires: true do
-    store['key1'] = 'val1'
-    advance(t_res / 4.0) # sleep less than a single time-space
-    store.key?('key1').should be true
-    store.fetch('key1').should == 'val1'
-    store.load('key1').should == 'val1'
-    advance min_ttl
-    2.times { advance_next_tick }
-    store.key?('key1').should be false
-    store.fetch('key1').should be_nil
-    store.load('key1').should be_nil
+  describe '#[]=' do
+    it 'sets the default expiration time' do
+      store['key1'] = 'val1'
+      expect(store['key1']).to eq 'val1'
+      advance min_ttl
+      2.times { advance_next_tick }
+      expect(store.key?('key1')).to be false
+    end
+  end
+
+  describe '#key?' do
+    it 'does not set an expiry by default' do
+      store.store('key1', 'val1', { expires: false })
+      expect(store.key?('key1')).to be true
+      advance min_ttl
+      2.times { advance_next_tick }
+      expect(store['key1']).to eq 'val1'
+    end
+  end
+
+  shared_examples :load do |method|
+    it 'does not set an expiry by default' do
+      store.store('key1', 'val1', { expires: false })
+      expect(store.public_send(method, 'key1')).to eq 'val1'
+      advance min_ttl
+      2.times { advance_next_tick }
+      expect(store.public_send(method, 'key1')).to eq 'val1'
+    end
+  end
+
+  describe '#[]' do
+    include_examples :load, :[]
+  end
+
+  describe '#load' do
+    include_examples :load, :load
+  end
+
+  describe '#fetch' do
+    include_examples :load, :fetch
+  end
+
+  describe '#create' do
+    it 'sets the default expiration time' do
+      store.create('key1', 'val1')
+      expect(store['key1']).to eq 'val1'
+      advance min_ttl
+      2.times { advance_next_tick }
+      expect(store.key?('key1')).to be false
+    end
+
+    it 'does not set default expiration if `expires: false` is passed' do
+      store.create('key1', 'val1', { expires: false })
+      advance min_ttl
+      2.times { advance_next_tick }
+      expect(store['key1']).to eq 'val1'
+    end
+
+    it 'does not set default expiration if the value already exists' do
+      store.create('key1', 'val1', { expires: false })
+      expect(store.create('key1', 'val1')).to be false
+      advance min_ttl
+      2.times { advance_next_tick }
+      expect(store['key1']).to eq 'val1'
+    end
+  end
+
+  describe '#store' do
+    it 'sets the default expiration time' do
+      store.store('key1', 'val1')
+      expect(store['key1']).to eq 'val1'
+      advance min_ttl
+      2.times { advance_next_tick }
+      expect(store.key?('key1')).to be false
+    end
+
+    it 'does not set default expiration if `expires: false` is passed' do
+      store.store('key1', 'val1', { expires: false })
+      advance min_ttl
+      2.times { advance_next_tick }
+      expect(store['key1']).to eq 'val1'
+    end
+  end
+
+  # Currently this isn't implemented - should it be?
+  skip '#increment' do
+    it 'sets the default expiration time' do
+      store.increment('key1')
+      expect(store['key1']).to eq '1'
+      advance min_ttl
+      2.times { advance_next_tick }
+      expect(store.key?('key1')).to be false
+    end
+
+    it 'does not set default expiration if `expires: false` is passed' do
+      store.increment('key1', 1, { expires: false })
+      advance min_ttl
+      2.times { advance_next_tick }
+      expect(store['key1']).to eq '1'
+    end
+  end
+
+  skip '#decrement' do
+    it 'sets the default expiration time' do
+      store.decrement('key1')
+      expect(store['key1']).to eq '-1'
+      advance min_ttl
+      2.times { advance_next_tick }
+      expect(store.key?('key1')).to be false
+    end
+
+    it 'does not set default expiration if `expires: false` is passed' do
+      store.decrement('key1', 1, { expires: false })
+      advance min_ttl
+      2.times { advance_next_tick }
+      expect(store['key1']).to eq '-1'
+    end
+  end
+
+  shared_examples :merge_update do |method|
+    it 'sets the default expiration time' do
+      store.public_send(method, { 'key1' => 'val1' })
+      expect(store['key1']).to eq 'val1'
+      advance min_ttl
+      2.times { advance_next_tick }
+      expect(store.key?('key1')).to be false
+    end
+
+    it 'does not set default expiration if `expires: false` is passed' do
+      store.public_send(method, { 'key1' => 'val1' }, { expires: false })
+      advance min_ttl
+      2.times { advance_next_tick }
+      expect(store['key1']).to eq 'val1'
+    end
+  end
+
+  describe '#merge!' do
+    include_examples :merge_update, :merge!
+  end
+
+  describe '#update' do
+    include_examples :merge_update, :update
+  end
+
+  describe '#values_at' do
+    it 'does not set an expiry by default' do
+      store.store('key1', 'val1', { expires: false })
+      expect(store.values_at('key1')).to eq ['val1']
+      advance min_ttl
+      2.times { advance_next_tick }
+      expect(store['key1']).to eq 'val1'
+    end
+  end
+
+  describe '#fetch_values' do
+    it 'does not set an expiry by default' do
+      store.store('key1', 'val1', { expires: false })
+      expect(store.fetch_values('key1')).to eq ['val1']
+      advance min_ttl
+      2.times { advance_next_tick }
+      expect(store['key1']).to eq 'val1'
+    end
+  end
+
+  describe '#slice' do
+    it 'does not set an expiry by default' do
+      store.store('key1', 'val1', { expires: false })
+      expect(store.slice('key1').to_a).to eq [%w{key1 val1}]
+      advance min_ttl
+      2.times { advance_next_tick }
+      expect(store['key1']).to eq 'val1'
+    end
   end
 end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -194,10 +194,6 @@ class MonetaSpecs
     new(specs: specs - [:store, :store_large, :transform_value, :marshallable_value])
   end
 
-  def with_default_expires
-    new(specs: specs + [:default_expires])
-  end
-
   def with_each_key
     new(specs: specs - [:not_each_key] | [:each_key])
   end
@@ -230,9 +226,10 @@ TRANSFORMER_SPECS = MonetaSpecs.new(
     :transform_value, :increment, :create, :features, :store_large,
     :not_each_key])
 
+DEFAULT_EXPIRES_SPECS = MonetaSpecs.new(specs: [:default_expires])
+
 module MonetaHelpers
   module ClassMethods
-
     def moneta_store store_name, options={}, &block
       name = self.description
       builder = proc do
@@ -264,28 +261,6 @@ module MonetaHelpers
       let(:values_meta) do
         [:branch, *specs.value.map{ |k| MonetaSpecs::VALUES[k] }.compact]
       end
-
-      # Used by tests that rely on MySQL.  These env vars can be used if you
-      # want to run the tests but don't want to grant root access to moneta
-      let(:mysql_host) { ENV['MYSQL_HOST'] || 'localhost' }
-      let(:mysql_port) { ENV['MYSQL_TCP_PORT'] || '3306' }
-      let(:mysql_socket) { ENV['MYSQL_SOCKET'] }
-      let(:mysql_username) { ENV['MONETA_MYSQL_USERNAME'] || 'root' }
-      let(:mysql_password) { ENV['MONETA_MYSQL_PASSWORD'] }
-      let(:mysql_database1) { ENV['MONETA_MYSQL_DATABASE1'] || 'moneta' }
-      let(:mysql_database2) { ENV['MONETA_MYSQL_DATABASE2'] || 'moneta2' }
-
-      let(:postgres_port) { ENV['PGPORT'] || '5432' }
-      let(:postgres_username) { ENV['PGUSER'] || 'postgres' }
-      let(:postgres_password) { ENV['PGPASSWORD'] }
-      let(:postgres_database1) { ENV['MONETA_POSTGRES_DATABSASE1'] || 'moneta1' }
-      let(:postgres_database2) { ENV['MONETA_POSTGRES_DATABSASE1'] || 'moneta2' }
-
-      let(:couch_login) { ENV['COUCH_LOGIN'] || 'admin' }
-      let(:couch_password) { ENV['COUCH_PASSWORD'] || 'password' }
-
-      let(:redis_host) { ENV.fetch('REDIS_HOST', 'localhost') }
-      let(:redis_port) { ENV.fetch('REDIS_PORT', '6379') }
 
       before do
         store = new_store
@@ -423,8 +398,29 @@ def marshal_error
   end
 end
 
-
 RSpec.shared_context :setup_moneta_store do |builder|
+  # Used by tests that rely on MySQL.  These env vars can be used if you
+  # want to run the tests but don't want to grant root access to moneta
+  let(:mysql_host) { ENV['MYSQL_HOST'] || 'localhost' }
+  let(:mysql_port) { ENV['MYSQL_TCP_PORT'] || '3306' }
+  let(:mysql_socket) { ENV['MYSQL_SOCKET'] }
+  let(:mysql_username) { ENV['MONETA_MYSQL_USERNAME'] || 'root' }
+  let(:mysql_password) { ENV['MONETA_MYSQL_PASSWORD'] }
+  let(:mysql_database1) { ENV['MONETA_MYSQL_DATABASE1'] || 'moneta' }
+  let(:mysql_database2) { ENV['MONETA_MYSQL_DATABASE2'] || 'moneta2' }
+
+  let(:postgres_port) { ENV['PGPORT'] || '5432' }
+  let(:postgres_username) { ENV['PGUSER'] || 'postgres' }
+  let(:postgres_password) { ENV['PGPASSWORD'] }
+  let(:postgres_database1) { ENV['MONETA_POSTGRES_DATABSASE1'] || 'moneta1' }
+  let(:postgres_database2) { ENV['MONETA_POSTGRES_DATABSASE1'] || 'moneta2' }
+
+  let(:couch_login) { ENV['COUCH_LOGIN'] || 'admin' }
+  let(:couch_password) { ENV['COUCH_PASSWORD'] || 'password' }
+
+  let(:redis_host) { ENV.fetch('REDIS_HOST', 'localhost') }
+  let(:redis_port) { ENV.fetch('REDIS_PORT', '6379') }
+
   before do
     @moneta_store_builder = builder
   end

--- a/spec/moneta/adapters/activesupportcache/adapter_activesupportcache_with_default_expires_spec.rb
+++ b/spec/moneta/adapters/activesupportcache/adapter_activesupportcache_with_default_expires_spec.rb
@@ -11,7 +11,7 @@ describe 'adapter_activesupportcache_with_default_expires', adapter: :ActiveSupp
       Moneta::Adapters::ActiveSupportCache.new(backend: backend, expires: min_ttl)
     end
 
-    moneta_specs ADAPTER_SPECS.without_concurrent.without_create.with_native_expires.with_default_expires
+    moneta_specs DEFAULT_EXPIRES_SPECS
   end
 
   context 'using MemoryStore' do

--- a/spec/moneta/adapters/cassandra/adapter_cassandra_with_default_expires_spec.rb
+++ b/spec/moneta/adapters/cassandra/adapter_cassandra_with_default_expires_spec.rb
@@ -14,5 +14,5 @@ describe 'adapter_cassandra_with_default_expires', isolate: true, retry: 3, adap
       create_keyspace: { durable_writes: false })
   end
 
-  moneta_specs ADAPTER_SPECS.without_increment.without_create.with_native_expires.with_default_expires.with_values(:nil).with_each_key
+  moneta_specs DEFAULT_EXPIRES_SPECS
 end

--- a/spec/moneta/adapters/memcached/dalli/adapter_memcached_dalli_spec.rb
+++ b/spec/moneta/adapters/memcached/dalli/adapter_memcached_dalli_spec.rb
@@ -20,6 +20,6 @@ describe 'adapter_memcached_dalli', retry: 3, adapter: :Memcached do
       Moneta::Adapters::MemcachedDalli.new(server: '127.0.0.1:11212', expires: min_ttl)
     end
 
-    moneta_specs NATIVE_EXPIRY_SPECS.with_default_expires
+    moneta_specs DEFAULT_EXPIRES_SPECS
   end
 end

--- a/spec/moneta/adapters/memcached/native/adapter_memcached_native_spec.rb
+++ b/spec/moneta/adapters/memcached/native/adapter_memcached_native_spec.rb
@@ -20,6 +20,6 @@ describe 'adapter_memcached_native', isolate: true, unstable: defined?(JRUBY_VER
       Moneta::Adapters::MemcachedNative.new(server: '127.0.0.1:11214', expires: min_ttl)
     end
 
-    moneta_specs NATIVE_EXPIRY_SPECS.with_default_expires
+    moneta_specs DEFAULT_EXPIRES_SPECS
   end
 end

--- a/spec/moneta/adapters/mongo/adapter_mongo_with_default_expires_spec.rb
+++ b/spec/moneta/adapters/mongo/adapter_mongo_with_default_expires_spec.rb
@@ -10,5 +10,5 @@ describe 'adapter_mongo_with_default_expires', isolate: true, adapter: :Mongo do
     )
   end
 
-  moneta_specs ADAPTER_SPECS.with_each_key.with_expires.with_default_expires.simplevalues_only
+  moneta_specs DEFAULT_EXPIRES_SPECS
 end

--- a/spec/moneta/adapters/redis/adapter_redis_spec.rb
+++ b/spec/moneta/adapters/redis/adapter_redis_spec.rb
@@ -15,6 +15,6 @@ describe 'adapter_redis', adapter: :Redis do
       Moneta::Adapters::Redis.new(host: redis_host, port: redis_port, db: 6, expires: min_ttl)
     end
 
-    moneta_specs NATIVE_EXPIRY_SPECS.with_default_expires
+    moneta_specs DEFAULT_EXPIRES_SPECS
   end
 end

--- a/spec/moneta/proxies/expires/expires_memory_with_default_expires_spec.rb
+++ b/spec/moneta/proxies/expires/expires_memory_with_default_expires_spec.rb
@@ -12,5 +12,5 @@ describe 'expires_memory_with_default_expires', isolate: true, proxy: :Expires d
     end
   end
 
-  moneta_specs STANDARD_SPECS.without_transform.with_expires.with_default_expires.without_persist.returnsame.with_each_key
+  moneta_specs DEFAULT_EXPIRES_SPECS
 end


### PR DESCRIPTION
The default_expires tests have a tendency to fail because we are generally racing against expiry while trying to test all the things.  This PR updates the setup so that tests on stores where default expiry is setup are just testing expiry functionality, and nothing else.  It probably won't solve the problem entirely, but should help to reduce the flakiness. 