### PR TITLE
Tests: update jdbc-h2 gem and add H2 to CI tests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -264,6 +264,30 @@ jobs:
     - name: Rspec
       run: bundle exec rspec -t sqlite -- spec/moneta
 
+  h2-adapters:
+    name: "H2 adapters"
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby-version: [jruby]
+
+    env:
+      BUNDLE_WITH: Sequel H2
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler: latest
+        bundler-cache: true
+
+    - name: Rspec
+      run: bundle exec rspec -t h2 -- spec/moneta
+
   rails5:
     name: "Rails 5"
     runs-on: ubuntu-latest

--- a/Gemfile
+++ b/Gemfile
@@ -135,7 +135,7 @@ group :KyotoCabinet, optional: true do
 end
 
 group :H2, optional: true do
-  gem 'activerecord-jdbch2-adapter', platforms: :jruby, github: 'jruby/activerecord-jdbc-adapter', glob: 'activerecord-jdbch2-adapter/*.gemspec', branch: '61-stable'
+  gem 'jdbc-h2'
 end
 
 group :GDBM, optional: true do

--- a/gemfiles/rails5.gemfile
+++ b/gemfiles/rails5.gemfile
@@ -6,10 +6,6 @@ gem 'actionpack', '~> 5.2'
 gem 'minitest', '~> 5.0'
 
 # Backends
-group :H2, optional: true do
-  gem 'activerecord-jdbch2-adapter', platforms: :jruby, github: 'jruby/activerecord-jdbc-adapter', glob: 'activerecord-jdbch2-adapter/*.gemspec', branch: '52-stable'
-end
-
 group :mysql, optional: true do
   gem 'activerecord-jdbcmysql-adapter', platforms: :jruby
   gem 'mysql2', platforms: :ruby

--- a/spec/moneta/adapters/sequel/adapter_sequel_spec.rb
+++ b/spec/moneta/adapters/sequel/adapter_sequel_spec.rb
@@ -29,7 +29,7 @@ describe ':Sequel adapter', adapter: :Sequel do
     include_examples :adapter_sequel, specs
   end
 
-  context "with H2 backend", unsupported: !defined?(JRUBY_VERSION) do
+  context "with H2 backend", h2: true, unsupported: !defined?(JRUBY_VERSION) do
     moneta_build do
       Moneta::Adapters::Sequel.new(opts.merge(db: h2_uri))
     end


### PR DESCRIPTION
This gets rid of any git references from the gemfile, which I think will make Debian people happy.